### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/packages/nestjs-trpc/lib/utils/file-scanner.ts
+++ b/packages/nestjs-trpc/lib/utils/file-scanner.ts
@@ -248,7 +248,7 @@ export class FileScanner {
 
                             for (const [alias, targets] of Object.entries(pathAliases)) {
                                 if ((alias === '@/*' || alias === '@*') && targets.length > 0) {
-                                    const target = targets[0].replace('*', '')
+                                    const target = targets[0].replace(/\*/g, '')
                                     resolvedBasePath = path.resolve(tsConfigDir, target)
                                     effectivePattern = filePath.replace('@/', '')
                                     aliasBaseResolved = true


### PR DESCRIPTION
Potential fix for [https://github.com/nexica/nestjs-trpc/security/code-scanning/7](https://github.com/nexica/nestjs-trpc/security/code-scanning/7)

To fix the problem, we need to ensure that all occurrences of the asterisk (`*`) character are removed from the alias target string, not just the first one. The best way to do this in JavaScript/TypeScript is to use a regular expression with the global (`g`) flag: `.replace(/\*/g, '')`. This change should be made at line 251 in `packages/nestjs-trpc/lib/utils/file-scanner.ts`. No new imports or methods are required, as this is a standard JavaScript feature.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
