### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main-pr-check.yml
+++ b/.github/workflows/main-pr-check.yml
@@ -15,6 +15,8 @@ concurrency:
 
 jobs:
   build-check:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       HUSKY: 0


### PR DESCRIPTION
Potential fix for [https://github.com/nexica/nestjs-trpc/security/code-scanning/9](https://github.com/nexica/nestjs-trpc/security/code-scanning/9)

To fix the problem, explicitly set the `permissions` block for the `build-check` job to limit the `GITHUB_TOKEN` to the minimum required privileges. Since the job only needs to read repository contents (for checkout and build), set `permissions: contents: read` under the `build-check` job. This change should be made directly under the `build-check:` job definition, before `runs-on`. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
