### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/other-pr-check.yml
+++ b/.github/workflows/other-pr-check.yml
@@ -1,4 +1,6 @@
 name: Other PR Check
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nexica/nestjs-trpc/security/code-scanning/10](https://github.com/nexica/nestjs-trpc/security/code-scanning/10)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/other-pr-check.yml`. The best way is to add it at the top level (just below the `name:` key), so it applies to all jobs in the workflow. Since the workflow only checks out code and runs a shell command, it only needs read access to repository contents. Therefore, set `permissions: contents: read` at the workflow level. No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
